### PR TITLE
Dispose of the UnityWebRequest in UserApiClient.cs

### DIFF
--- a/Runtime/Communication/ElympicsImplementations/UserApiClient.cs
+++ b/Runtime/Communication/ElympicsImplementations/UserApiClient.cs
@@ -91,6 +91,7 @@ namespace Elympics
 			var ctRegistration = ct.Register(() =>
 			{
 				requestOp.webRequest.Abort();
+				requestOp.webRequest.Dispose();
 				callback(null, null);
 			});
 			requestOp.completed += _ =>
@@ -105,6 +106,7 @@ namespace Elympics
 				var response = JsonUtility.FromJson<T>(requestOp.webRequest.downloadHandler.text);
 				Debug.Log($"[Elympics] Received response from {requestOp.webRequest.url}\n{requestOp.webRequest.downloadHandler.text}");
 				callback(response, null);
+				requestOp.webRequest.Dispose();
 			};
 		}
 


### PR DESCRIPTION
Fixes the following stack trace:
![image](https://user-images.githubusercontent.com/3093213/218730813-11ac3960-027a-413a-a03d-2c7b9b9e6ac9.png)
